### PR TITLE
Fix ci thrift detection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: $HOME/install/bin/thrift
-          key: ${{ runner.os }}-thrift
+          key: ${{ runner.os }}-thrift-new
 
       - name: Make Thrift Compiler
         if: steps.cache-thrift.outputs.cache-hit != 'true'
@@ -55,6 +55,10 @@ jobs:
           make
           make install
           popd
+          ls -al $HOME/install/bin
+
+      - name: Check Thrift install
+        run: |
           ls -al $HOME/install/bin
           echo "$HOME/install/bin" >> $GITHUB_PATH
 
@@ -88,7 +92,6 @@ jobs:
       - name: Run tests
         run: |
           echo $PATH
-          thrift --help
           WHATSOPT_COVERALLS=1 bundle exec rails test
 
       - name: Coveralls 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
           make
           make install
           popd
-          ls $HOME/install
+          ls -al $HOME/install/bin
           echo "$HOME/install/bin" >> $GITHUB_PATH
 
       - name: Setup Node
@@ -86,7 +86,10 @@ jobs:
           RAILS_ENV=test bundle exec rake webpacker:compile
 
       - name: Run tests
-        run: WHATSOPT_COVERALLS=1 bundle exec rails test
+        run: |
+          echo $PATH
+          thrift --help
+          WHATSOPT_COVERALLS=1 bundle exec rails test
 
       - name: Coveralls 
         uses: coverallsapp/github-action@master


### PR DESCRIPTION
Following #70, this PR fixes PATH variable to take into account that thrift is not installed in system path but in custom location. The impact was that Thrift guarded tests were not run (hence the decrease of the coverage which I did not understand at first).