### PR TITLE
Ft set input defaults

### DIFF
--- a/app/lib/whats_opt/templates/openmdao_main_base.py.erb
+++ b/app/lib/whats_opt/templates/openmdao_main_base.py.erb
@@ -53,6 +53,8 @@ class <%= @mda.py_classname %>Base(<%= @impl.parallel_group ? "ParallelGroup" : 
 <% end -%>
 
     def setup(self): 
+<% @mda.input_variables.each do |dv| %>
+        self.set_input_defaults('<%= dv.name %>', val=<%= dv.init_py_value %>)<% end -%>
 <% @mda.disciplines.nodes.each do |d| %>
         self.add_subsystem('<%= d.py_classname %>', self.create_<%= d.basename %>(),
                            promotes=[<%= d.variables.map(&:py_varname).map{|v| "'#{v}'"}.join(', ') %>])<% end -%>

--- a/app/models/discipline.rb
+++ b/app/models/discipline.rb
@@ -19,7 +19,7 @@ class Discipline < ApplicationRecord
   before_destroy :_destroy_connections
   after_destroy :_refresh_analysis_connections
 
-  has_many :variables, -> { includes(:parameter).order("name ASC") }, dependent: :destroy
+  has_many :variables, -> { includes([:parameter, :distributions, :scaling]).order("name ASC") }, dependent: :destroy
   # has_many :variables, :dependent => :destroy
   has_one :analysis_discipline, dependent: :destroy, autosave: true
   has_one :sub_analysis, through: :analysis_discipline, source: :analysis


### PR DESCRIPTION
With the removal of `IndepVarComp` #79, it seems to be best to provide input defaults to solve possible discrepencies (due to user inputs) between discipline consumers within nested analyses hierarchy.  