### PR TITLE
Fix group initialization

### DIFF
--- a/app/lib/whats_opt/templates/openmdao_analysis.py.erb
+++ b/app/lib/whats_opt/templates/openmdao_analysis.py.erb
@@ -5,25 +5,39 @@ from <%= @mda.py_full_modulename %>_base import <%= @mda.py_classname %>Base, <%
 
 
 class <%= @mda.py_classname %>Factory(<%= @mda.py_classname %>FactoryBase):
-    """ 
-    A factory to create disciplines of <%= @mda.py_classname %> analysis.
-    One can override create methods from the base class 
-    to handle disciplines creation as needed.
-    """
-    pass
+    """ A factory to create disciplines of <%= @mda.py_classname %> analysis. """
+
+    # One can override here create methods from the base class to take control over disciplines creation
+    # then pass an instance of this class as the 'factory' argument of the constructor (see run_*.py scripts),
+    # example: my_analysis = <%= @mda.py_classname %>(factory=<%= @mda.py_classname %>Factory())
+
 
 class <%= @mda.py_classname %>(<%= @mda.py_classname %>Base):
-    """ An OpenMDAO component to encapsulate <%= @mda.py_classname %> analysis """
-    def __init__(self, factory=<%= @mda.py_classname %>Factory()):
-        super().__init__(factory)
+    """ An OpenMDAO Group to encapsulate <%= @mda.py_classname %> analysis 
+    see https://openmdao.org/newdocs/versions/latest/features/core_features/working_with_groups/main.html
+    """
+    # One can override here default behaviour provided by WhatsOpt in the base class.
 
-        # Example of manual solver adjusments (imports should be adjusted accordingly)
-        # self.nonlinear_solver = NewtonSolver()
-        # self.nonlinear_solver.options['maxiter'] = 20
-        # self.linear_solver = DirectSolver()
+    # def initialize():
+    # Here one can adjust component initialization 
 
-    def setup(self):
-        super().setup()
+    # Example adding options 
+    # see https://openmdao.org/newdocs/versions/latest/features/core_features/working_with_components/options.html
+    #
+    #     self.options.declare("n_engines", types=int)
+
+    # Example of manual solver adjusments (imports should be adjusted accordingly)
+    # see https://openmdao.org/newdocs/versions/latest/features/core_features/controlling_solver_behavior/main.html
+    # 
+    #     self.nonlinear_solver = NewtonSolver()
+    #     self.nonlinear_solver.options['maxiter'] = 20
+    #     self.linear_solver = DirectSolver()
+
+    # def setup(self):
+    #     super().setup()
+    #
+    # As an example, here if needs be, one can add code to adjust 
+    # setup (done in parent base class) regarding options defined in initialize  
 
 
 if __name__ == "__main__":

--- a/app/lib/whats_opt/templates/openmdao_analysis_base.py.erb
+++ b/app/lib/whats_opt/templates/openmdao_analysis_base.py.erb
@@ -28,8 +28,8 @@ class <%= @mda.py_classname %>FactoryBase():
     """ 
     A factory for all plain disciplines of <%= @mda.name %> analysis.
 
-    User can override methods in a subclass to take control over disciplines creation 
-    and pass that subclass to the analysis constructor.
+    One can override methods in a subclass to take control over disciplines creation 
+    and pass that subclass to the analysis constructor as a factory argument.
     """
 <% @mda.all_plain_disciplines.each do |disc| %>
     def create_<%= disc.snake_modulename %>(self):
@@ -45,15 +45,10 @@ class <%= @mda.py_classname %>FactoryBase():
 
 class <%= @mda.py_classname %>Base(<%= @impl.parallel_group ? "om.ParallelGroup" : "om.Group" %>):
     """ An OpenMDAO base component to encapsulate <%= @mda.py_classname %> MDA """
-    def __init__(self, factory=<%= @mda.py_classname %>FactoryBase()):
-        """
-        Parameters
-        ----------
-            factory: Subclass of <%= @mda.py_classname %>Factory 
-            Used to control disciplines creation (default to <%= @mda.py_classname %>FactoryBase)
-        """
-        super(). __init__()
-        self._factory = factory
+
+    def initialize(self):
+        self.options.declare('factory', default=<%= @mda.py_classname %>FactoryBase(), 
+                             types=<%= @mda.py_classname %>FactoryBase)
 
         self.nonlinear_solver = <%= @impl.nonlinear_solver.name %>()
 <% unless @impl.nonlinear_solver.runonce? -%>
@@ -85,10 +80,10 @@ class <%= @mda.py_classname %>Base(<%= @impl.parallel_group ? "om.ParallelGroup"
         User can override this method in a subclass 
         to take control over <%= a.py_classname %> sub analysis creation.
         """
-        return <%= a.py_classname %>(factory=self._factory)
+        return <%= a.py_classname %>(factory=self.options["factory"])
 <% end -%>
 <% @mda.plain_disciplines.each do |disc| %>
     def create_<%= disc.basename %>(self):
-        return self._factory.create_<%= disc.snake_modulename %>()
+        return self.options["factory"].create_<%= disc.snake_modulename %>()
 <% end %>
 

--- a/app/lib/whats_opt/templates/openmdao_discipline.py.erb
+++ b/app/lib/whats_opt/templates/openmdao_discipline.py.erb
@@ -7,7 +7,7 @@ class <%= @discipline.py_classname %>(<%= @discipline.py_classname %>Base):
 
     def compute(self, inputs, outputs):
         """ <%= @discipline.py_classname %> computation """
-        # Here comes discipline resolution code
+        # Here one can implement discipline resolution code
         # (python function or module, external software calls...)
 
 <%- if @discipline.input_variables.numeric.empty? && @discipline.output_variables.numeric.empty? -%>

--- a/app/lib/whats_opt/templates/openmdao_discipline_base.py.erb
+++ b/app/lib/whats_opt/templates/openmdao_discipline_base.py.erb
@@ -5,7 +5,9 @@ from numpy import nan, inf
 import openmdao.api as om
 
 class <%= @discipline.py_classname %>Base(<%= @dimpl.implicit_component ? "om.ImplicitComponent" : "om.ExplicitComponent" %>):
-    """ An OpenMDAO base component to encapsulate <%= @discipline.py_classname %> discipline """
+    """ An OpenMDAO base component to encapsulate <%= @discipline.py_classname %> discipline. 
+    This class defines inputs and outputs of the discipline and declare partials.
+    """
 
 <% unless @discipline.variables.empty? -%>
     def setup(self):
@@ -21,8 +23,10 @@ class <%= @discipline.py_classname %>Base(<%= @dimpl.implicit_component ? "om.Im
 <% end -%>
 <% end -%>
 
+<%- if @discipline.input_variables.numeric.empty? || @discipline.output_variables.numeric.empty? -%>
     def setup_partials(self):
         self.declare_partials('*', '*', method='<%= @dimpl.support_derivatives ? "exact" : "fd" %>')
+<% end -%>
 <% else -%>
     pass
 <% end -%>


### PR DESCRIPTION
This PR changes the template used to generate the analysis code to use the OpenMDAO way to initialize the group. 
Instead of using `__init__`, use `initialize` to pass the discipline factory. 

The current implementation with `__init__` was wrong as well as it did not pass `**kwargs` used by parent OpenMDAO classes. 