### PR TITLE
Fix use units handling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
           export THRIFT_VERSION=0.15.0
           export buildDeps="automake bison curl flex g++ libboost-dev libboost-filesystem-dev libboost-program-options-dev libboost-system-dev libboost-test-dev  libevent-dev libssl-dev libtool make pkg-config"
           sudo apt-get install -y --no-install-recommends $buildDeps && sudo rm -rf /var/lib/apt/lists/*
-          curl -sSL "http://apache.mirrors.spacedump.net/thrift/$THRIFT_VERSION/thrift-$THRIFT_VERSION.tar.gz" -o thrift.tar.gz
+          curl -sSL "https://dlcdn.apache.org/thrift/$THRIFT_VERSION/thrift-$THRIFT_VERSION.tar.gz" -o thrift.tar.gz
           mkdir -p thrift
           mkdir -p install
           tar zxf thrift.tar.gz -C ${PWD}/thrift --strip-components=1

--- a/app/lib/whats_opt/openmdao_variable.rb
+++ b/app/lib/whats_opt/openmdao_variable.rb
@@ -25,9 +25,10 @@ module WhatsOpt
       end
     end
 
-    def py_desc
-      desc = self.desc
-      desc += " (#{self.units})"
+    def extended_desc
+      desc = ""
+      desc = self.desc unless self.desc.blank? 
+      desc += " (#{self.units})" unless self.units.blank?
       desc
     end
 
@@ -89,8 +90,8 @@ module WhatsOpt
 
     def escaped_desc
       s = ""
-      unless self.desc.blank?
-        s = self.desc.gsub("'", "\\\\'")
+      unless self.extended_desc.blank?
+        s = self.extended_desc.gsub("'", "\\\\'")
       end
       s
     end

--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -613,6 +613,13 @@ class Analysis < ApplicationRecord
     conn.update_connections!(params)
   end
 
+  def update_all_impls(use_units: true)
+    root_analysis.openmdao_impl.update(use_units: use_units)
+    root_analysis.descendants.each do |child|
+      child.openmdao_impl.update(use_units: use_units)
+    end
+  end
+
   def destroy_connection!(conn, sub_analysis_check: true)
     Analysis.transaction do
       varname = conn.from.name

--- a/app/models/openmdao_analysis_impl.rb
+++ b/app/models/openmdao_analysis_impl.rb
@@ -91,7 +91,7 @@ class OpenmdaoAnalysisImpl < ActiveRecord::Base
       self.parallel_group = false if parallel_group.blank?
       self.nonlinear_solver ||= Solver.new(name: "NonlinearBlockGS")
       self.linear_solver ||= Solver.new(name: "ScipyKrylov")
-      self.use_units = false if use_units.blank?
+      self.use_units = true if use_units.nil?
       self.optimization_driver = :scipy_optimizer_slsqp if optimization_driver.blank?
       self.package_name = NULL_PACKAGE_NAME if package_name.blank?
     end

--- a/app/models/openmdao_analysis_impl.rb
+++ b/app/models/openmdao_analysis_impl.rb
@@ -29,11 +29,11 @@ class OpenmdaoAnalysisImpl < ActiveRecord::Base
     nonlinear_solver.update(impl_attrs[:nonlinear_solver]) if impl_attrs.key?(:nonlinear_solver)
     linear_solver.update(impl_attrs[:linear_solver]) if impl_attrs.key?(:linear_solver)
     parallel = impl_attrs[:parallel_group]
-    self.parallel_group = parallel unless parallel.nil?
+    self.update(parallel_group: parallel) unless parallel.nil?
     use_units = impl_attrs[:use_units]
-    self.use_units = use_units unless use_units.nil?
+    self.analysis.update_all_impls(use_units: use_units) unless use_units.nil?
     optimization_driver = impl_attrs[:optimization_driver]
-    self.optimization_driver = optimization_driver unless optimization_driver.nil?
+    self.update(optimization_driver: optimization_driver) unless optimization_driver.nil?
     packaging = impl_attrs[:packaging]
     self.update(package_name: packaging[:package_name]) unless packaging.nil?
     impl_attrs[:nodes]&.each do |dattr|

--- a/test/controllers/api/v1/openmdao_impls_controller_test.rb
+++ b/test/controllers/api/v1/openmdao_impls_controller_test.rb
@@ -49,4 +49,16 @@ class Api::V1::OpenmdaoImplsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "onerasego_optimizer_segomoe", @mda.openmdao_impl.optimization_driver
   end
 
+  test "should propagate use_units change" do
+    outermda = analyses(:outermda)
+    oimpl = outermda.openmdao_impl
+    innermda = analyses(:innermda)
+    inner_oimpl = innermda.openmdao_impl
+    refute inner_oimpl.use_units
+    put api_v1_mda_openmdao_impl_url(outermda), params: { openmdao_impl: { use_units: true }, requested_at: Time.now },
+    as: :json, headers: @auth_headers
+    assert_response :success
+    inner_oimpl.reload
+    assert inner_oimpl.use_units
+  end
 end

--- a/test/controllers/api/v1/openmdao_impls_controller_test.rb
+++ b/test/controllers/api/v1/openmdao_impls_controller_test.rb
@@ -22,13 +22,22 @@ class Api::V1::OpenmdaoImplsControllerTest < ActionDispatch::IntegrationTest
     assert @mda.openmdao_impl.parallel_group
   end
 
-  test "should update openmdao impl use_units flag" do
+  test "should update openmdao impl use_units flag to true" do
     refute @mda.openmdao_impl.use_units
     put api_v1_mda_openmdao_impl_url(@mda), params: { openmdao_impl: { use_units: true }, requested_at: Time.now },
                                             as: :json, headers: @auth_headers
     assert_response :success
     @mda.reload
     assert @mda.openmdao_impl.use_units
+  end
+
+  test "should update openmdao impl use_units flag to false" do
+    @mda.openmdao_impl.update(use_units: true)
+    put api_v1_mda_openmdao_impl_url(@mda), params: { openmdao_impl: { use_units: false }, requested_at: Time.now },
+                                            as: :json, headers: @auth_headers
+    assert_response :success
+    @mda.reload
+    refute @mda.openmdao_impl.use_units
   end
 
   test "should update openmdao impl optim driver" do

--- a/test/lib/whats_opt/openmdao_variable_test.rb
+++ b/test/lib/whats_opt/openmdao_variable_test.rb
@@ -7,8 +7,18 @@ class FakeOpenmdaoVariable < Struct.new(:name, :type, :shape, :io_mode, :units, 
 end
 
 class OpenmdaoMappingTest < ActiveSupport::TestCase
-  def test_should_have_a_description
+  def test_should_have_a_description_escaped
     @var = FakeOpenmdaoVariable.new("VAR2tesT", :Float, 1, :in, "m", "description")
-    assert_equal "description (m)", @var.py_desc
+    assert_equal "description (m)", @var.escaped_desc
   end
+  def test_should_have_a_description_with_unit
+    @var = FakeOpenmdaoVariable.new("VAR2tesT", :Float, 1, :in, "m", "'description'")
+    assert_equal "\\'description\\' (m)", @var.escaped_desc
+  end
+
+  def test_should_have_a_description_without_unit
+    @var = FakeOpenmdaoVariable.new("VAR2tesT", :Float, 1, :in, "", "description")
+    assert_equal "description", @var.extended_desc
+  end
+
 end

--- a/test/models/openmdao_analysis_impl_test.rb
+++ b/test/models/openmdao_analysis_impl_test.rb
@@ -16,11 +16,13 @@ class OpenmdaoAnalysisImplTest < ActiveSupport::TestCase
 
   test "should update parallel flag" do
     @oai.update_impl({parallel_group: true, use_units: true})
+    @oai.reload
     assert_not @oai.parallel_group.nil?
     assert @oai.parallel_group
     assert_not @oai.use_units.nil?
     assert @oai.use_units
     @oai.update_impl({parallel_group: false, use_units: false})
+    @oai.reload
     assert_not @oai.parallel_group
     assert_not @oai.use_units
   end


### PR DESCRIPTION
This PR changes handling of units info:
* use units in OpenMDAO code generation by default,
* concatenate units to description string
* spread 'use units' checkbox setting accross analysis hierarchy 