### PR TITLE
Specify integer for reference in package migration

### DIFF
--- a/db/migrate/20230403155358_create_packages.rb
+++ b/db/migrate/20230403155358_create_packages.rb
@@ -2,8 +2,8 @@ class CreatePackages < ActiveRecord::Migration[7.0]
   def change
     create_table :packages do |t|
       t.text :description
-      t.references :analysis, foreign_key: true
-
+      t.references :analysis, foreign_key: true, type: :integer
+      
       t.timestamps
     end
   end


### PR DESCRIPTION
With MySQL we need to specify integer for reference id