### PR TITLE
Analysis lock in readonly mode

### DIFF
--- a/app/controllers/analyses_controller.rb
+++ b/app/controllers/analyses_controller.rb
@@ -96,7 +96,7 @@ class AnalysesController < ApplicationController
     end
 
     def mda_params
-      params.require(:analysis).permit(:name, :public, design_project: [:id])
+      params.require(:analysis).permit(:name, :public, :locked, design_project: [:id])
     end
     
     def save_journal

--- a/app/controllers/api/v1/analyses_controller.rb
+++ b/app/controllers/api/v1/analyses_controller.rb
@@ -118,6 +118,7 @@ class Api::V1::AnalysesController < Api::V1::ApiMdaUpdaterController
         :note,
         :design_project_id,
         :public,
+        :locked,
         import: [:analysis, disciplines: [] ],
         disciplines_attributes: [
             :name,

--- a/app/controllers/api/v1/design_projects_controller.rb
+++ b/app/controllers/api/v1/design_projects_controller.rb
@@ -45,6 +45,7 @@ private
       analyses_attributes: [:name,
                             :note,
                             :public,
+                            :locked,
                             disciplines_attributes: [
                               :name,
                               variables_attributes: [

--- a/app/helpers/analyses_helper.rb
+++ b/app/helpers/analyses_helper.rb
@@ -2,7 +2,7 @@
 
 module AnalysesHelper
   def lock_status(analysis)
-    analysis.public ? "" : raw('<span><i class="fa fa-lock"></i></span>')
+    analysis.locked ? "" : raw('<span><i class="fa fa-lock"></i></span>')
   end
 
   def link_to_analysis_if_authorized(analysis, user)

--- a/app/helpers/analyses_helper.rb
+++ b/app/helpers/analyses_helper.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 module AnalysesHelper
-  def lock_status(analysis)
-    analysis.locked ? "" : raw('<span><i class="fa fa-lock"></i></span>')
-  end
 
   def link_to_analysis_if_authorized(analysis, user)
     if policy(analysis).show?
@@ -86,8 +83,11 @@ module AnalysesHelper
     raw(res)
   end
 
-  def ownership(analysis)
-    res=""
+  def analysis_access(analysis)
+    res = ""
+    if analysis.locked
+      res += ' <i class="fa fa-lock"></i></span>'
+    end
     unless analysis.public
       res += ' <i class="fas fa-user-secret" title="Analysis with restricted access"></i>'
     end

--- a/app/javascript/mda_viewer/components/AnalysisEditor.jsx
+++ b/app/javascript/mda_viewer/components/AnalysisEditor.jsx
@@ -93,11 +93,10 @@ class AnalysisEditor extends React.PureComponent {
   render() {
     let teamMembers = null;
     const {
-      analysisPublic, analysisLocked, analysisMembers, analysisCoOwners,
+      analysisPublic, analysisMembers, analysisCoOwners,
       analysisPermissionsEditable, onAnalysisUserSearch, onAnalysisUserSelected,
       onAnalysisUserDelete, onAnalysisUpdate, newAnalysisName,
-      onAnalysisNameChange, onAnalysisNoteChange,
-      onAnalysisPublicChange, onAnalysisLockedChange,
+      onAnalysisNameChange, onAnalysisNoteChange, onAnalysisPublicChange,
       mdaId, note, onProjectSearch, onProjectSelected, mdaProject,
     } = this.props;
     if (!analysisPublic) {
@@ -173,30 +172,6 @@ class AnalysisEditor extends React.PureComponent {
         <hr />
         <div className="editor-section">
           <div className="editor-section-label">
-            <i className="fas fa-lock" title="Analysis locked in readonly mode" />
-            {' '}
-            Readonly
-            {' '}
-            <small>(when locked in readonly mode, edition or deletion are disabled)</small>
-          </div>
-          <form className="form" onSubmit={onAnalysisUpdate}>
-            <div className="mb-3 form-check">
-              <label htmlFor="locked" className="form-check-label">
-                <input
-                  type="checkbox"
-                  className="form-check-input"
-                  defaultChecked={analysisLocked}
-                  id="locked"
-                  onChange={onAnalysisLockedChange}
-                />
-                Locked
-              </label>
-            </div>
-          </form>
-        </div>
-        <hr />
-        <div className="editor-section">
-          <div className="editor-section-label">
             <i className="fas fa-users-cog" title="Analysis has co-owners" />
             {' '}
             Collaboration
@@ -242,7 +217,6 @@ AnalysisEditor.propTypes = {
   mdaProject: PropTypes.object.isRequired,
   newAnalysisName: PropTypes.string.isRequired,
   analysisPublic: PropTypes.bool.isRequired,
-  analysisLocked: PropTypes.bool.isRequired,
   analysisPermissionsEditable: PropTypes.bool.isRequired,
   analysisMembers: PropTypes.array.isRequired,
   analysisCoOwners: PropTypes.array.isRequired,
@@ -250,7 +224,6 @@ AnalysisEditor.propTypes = {
   onAnalysisNameChange: PropTypes.func.isRequired,
   onAnalysisNoteChange: PropTypes.func.isRequired,
   onAnalysisPublicChange: PropTypes.func.isRequired,
-  onAnalysisLockedChange: PropTypes.func.isRequired,
   onAnalysisUserSearch: PropTypes.func.isRequired,
   onAnalysisUserSelected: PropTypes.func.isRequired,
   onAnalysisUserDelete: PropTypes.func.isRequired,

--- a/app/javascript/mda_viewer/components/AnalysisEditor.jsx
+++ b/app/javascript/mda_viewer/components/AnalysisEditor.jsx
@@ -93,9 +93,11 @@ class AnalysisEditor extends React.PureComponent {
   render() {
     let teamMembers = null;
     const {
-      analysisPublic, analysisMembers, analysisCoOwners, analysisPermissionsEditable,
-      onAnalysisUserSearch, onAnalysisUserSelected, onAnalysisUserDelete, onAnalysisUpdate,
-      newAnalysisName, onAnalysisNameChange, onAnalysisNoteChange, onAnalysisPublicChange,
+      analysisPublic, analysisLocked, analysisMembers, analysisCoOwners,
+      analysisPermissionsEditable, onAnalysisUserSearch, onAnalysisUserSelected,
+      onAnalysisUserDelete, onAnalysisUpdate, newAnalysisName,
+      onAnalysisNameChange, onAnalysisNoteChange,
+      onAnalysisPublicChange, onAnalysisLockedChange,
       mdaId, note, onProjectSearch, onProjectSelected, mdaProject,
     } = this.props;
     if (!analysisPublic) {
@@ -171,6 +173,30 @@ class AnalysisEditor extends React.PureComponent {
         <hr />
         <div className="editor-section">
           <div className="editor-section-label">
+            <i className="fas fa-lock" title="Analysis locked in readonly mode" />
+            {' '}
+            Readonly
+            {' '}
+            <small>(when locked in readonly mode, edition or deletion are disabled)</small>
+          </div>
+          <form className="form" onSubmit={onAnalysisUpdate}>
+            <div className="mb-3 form-check">
+              <label htmlFor="locked" className="form-check-label">
+                <input
+                  type="checkbox"
+                  className="form-check-input"
+                  defaultChecked={analysisLocked}
+                  id="locked"
+                  onChange={onAnalysisLockedChange}
+                />
+                Locked
+              </label>
+            </div>
+          </form>
+        </div>
+        <hr />
+        <div className="editor-section">
+          <div className="editor-section-label">
             <i className="fas fa-users-cog" title="Analysis has co-owners" />
             {' '}
             Collaboration
@@ -216,6 +242,7 @@ AnalysisEditor.propTypes = {
   mdaProject: PropTypes.object.isRequired,
   newAnalysisName: PropTypes.string.isRequired,
   analysisPublic: PropTypes.bool.isRequired,
+  analysisLocked: PropTypes.bool.isRequired,
   analysisPermissionsEditable: PropTypes.bool.isRequired,
   analysisMembers: PropTypes.array.isRequired,
   analysisCoOwners: PropTypes.array.isRequired,
@@ -223,6 +250,7 @@ AnalysisEditor.propTypes = {
   onAnalysisNameChange: PropTypes.func.isRequired,
   onAnalysisNoteChange: PropTypes.func.isRequired,
   onAnalysisPublicChange: PropTypes.func.isRequired,
+  onAnalysisLockedChange: PropTypes.func.isRequired,
   onAnalysisUserSearch: PropTypes.func.isRequired,
   onAnalysisUserSelected: PropTypes.func.isRequired,
   onAnalysisUserDelete: PropTypes.func.isRequired,

--- a/app/javascript/mda_viewer/index.jsx
+++ b/app/javascript/mda_viewer/index.jsx
@@ -78,6 +78,7 @@ class MdaViewer extends React.Component {
     this.handleAnalysisNameChange = this.handleAnalysisNameChange.bind(this);
     this.handleAnalysisNoteChange = this.handleAnalysisNoteChange.bind(this);
     this.handleAnalysisPublicChange = this.handleAnalysisPublicChange.bind(this);
+    this.handleAnalysisLockedChange = this.handleAnalysisLockedChange.bind(this);
     this.handleAnalysisUserSearch = this.handleAnalysisUserSearch.bind(this);
     this.handleAnalysisUserCreate = this.handleAnalysisUserCreate.bind(this);
     this.handleAnalysisUserDelete = this.handleAnalysisUserDelete.bind(this);
@@ -319,6 +320,20 @@ class MdaViewer extends React.Component {
       { public: !mda.public },
       () => {
         const newState = update(this.state, { mda: { public: { $set: !mda.public } } });
+        this.setState(newState);
+      },
+      this.displayError,
+    );
+    return false;
+  }
+
+  handleAnalysisLockedChange() {
+    const { mda } = this.state;
+    this.api.updateAnalysis(
+      mda.id,
+      { locked: !mda.locked },
+      () => {
+        const newState = update(this.state, { mda: { locked: { $set: !mda.locked } } });
         this.setState(newState);
       },
       this.displayError,
@@ -602,6 +617,10 @@ class MdaViewer extends React.Component {
       if (!db.mda.public) {
         restricted = (<i className="fas fa-user-secret" title="Analysis with restricted access" />);
       }
+      let locked;
+      if (db.mda.locked) {
+        restricted = (<i className="fas fa-lock" title="Analysis locked in readonly mode" />);
+      }
       let co_owned;
       if (analysisCoOwners.length > 0) {
         co_owned = (<i className="fas fa-users-cog" title="Analysis has co-owners" />);
@@ -626,6 +645,8 @@ class MdaViewer extends React.Component {
               (#
               {mda.id}
               )
+              {' '}
+              {locked}
               {' '}
               {restricted}
               {' '}
@@ -715,6 +736,7 @@ class MdaViewer extends React.Component {
                 note={db.mda.note}
                 newAnalysisName={newAnalysisName}
                 analysisPublic={mda.public}
+                analysisLocked={mda.locked}
                 analysisPermissionsEditable={analysisPermissionsEditable}
                 analysisMembers={analysisMembers}
                 analysisCoOwners={analysisCoOwners}
@@ -722,6 +744,7 @@ class MdaViewer extends React.Component {
                 onAnalysisNameChange={this.handleAnalysisNameChange}
                 onAnalysisNoteChange={this.handleAnalysisNoteChange}
                 onAnalysisPublicChange={this.handleAnalysisPublicChange}
+                onAnalysisLockedChange={this.handleAnalysisLockedChange}
                 onAnalysisUserSearch={this.handleAnalysisUserSearch}
                 onAnalysisUserSelected={this.handleAnalysisUserCreate}
                 onAnalysisUserDelete={this.handleAnalysisUserDelete}
@@ -917,6 +940,7 @@ MdaViewer.propTypes = {
     owner: PropTypes.object.isRequired,
     name: PropTypes.string.isRequired,
     public: PropTypes.bool.isRequired,
+    locked: PropTypes.bool.isRequired,
     note: PropTypes.string.isRequired,
     id: PropTypes.number.isRequired,
     path: PropTypes.array.isRequired,

--- a/app/javascript/mda_viewer/index.jsx
+++ b/app/javascript/mda_viewer/index.jsx
@@ -618,8 +618,10 @@ class MdaViewer extends React.Component {
         restricted = (<i className="fas fa-user-secret" title="Analysis with restricted access" />);
       }
       let lock;
+      let locked = ('');
       if (db.mda.locked) {
-        lock = (<i className="fas fa-lock" title="Analysis locked in readonly mode" />);
+        lock = (<i className="fas fa-lock" title="Analysis is locked readonly" />);
+        locked = lock;
       } else {
         lock = (<i className="fas fa-unlock" title="Analysis is editable/deletable" />);
       }
@@ -653,7 +655,7 @@ class MdaViewer extends React.Component {
               {mda.id}
               )
               {' '}
-              {lock}
+              {locked}
               {' '}
               {restricted}
               {' '}

--- a/app/javascript/mda_viewer/index.jsx
+++ b/app/javascript/mda_viewer/index.jsx
@@ -617,10 +617,17 @@ class MdaViewer extends React.Component {
       if (!db.mda.public) {
         restricted = (<i className="fas fa-user-secret" title="Analysis with restricted access" />);
       }
-      let locked;
+      let lock;
       if (db.mda.locked) {
-        restricted = (<i className="fas fa-lock" title="Analysis locked in readonly mode" />);
+        lock = (<i className="fas fa-lock" title="Analysis locked in readonly mode" />);
+      } else {
+        lock = (<i className="fas fa-unlock" title="Analysis is editable/deletable" />);
       }
+      const tab_disabled = db.mda.locked ? 'disabled' : '';
+      const tab_lock_active = db.mda.locked ? 'active' : '';
+      const tab_vars_active = !db.mda.locked ? 'active' : '';
+      const tab_lock_show = db.mda.locked ? 'show' : '';
+      const tab_vars_show = !db.mda.locked ? 'show' : '';
       let co_owned;
       if (analysisCoOwners.length > 0) {
         co_owned = (<i className="fas fa-users-cog" title="Analysis has co-owners" />);
@@ -646,7 +653,7 @@ class MdaViewer extends React.Component {
               {mda.id}
               )
               {' '}
-              {locked}
+              {lock}
               {' '}
               {restricted}
               {' '}
@@ -661,7 +668,20 @@ class MdaViewer extends React.Component {
           <ul className="nav nav-tabs" id="myTab" role="tablist">
             <li className="nav-item">
               <a
-                className="nav-link"
+                className={`nav-link ${tab_lock_active}`}
+                id="lock-tab"
+                data-bs-toggle="tab"
+                href="#lock"
+                role="tab"
+                aria-controls="lock"
+                aria-selected="false"
+              >
+                { lock }
+              </a>
+            </li>
+            <li className="nav-item">
+              <a
+                className={`nav-link ${tab_disabled}`}
                 id="analysis-tab"
                 data-bs-toggle="tab"
                 href="#analysis"
@@ -674,7 +694,7 @@ class MdaViewer extends React.Component {
             </li>
             <li className="nav-item">
               <a
-                className="nav-link"
+                className={`nav-link ${tab_disabled}`}
                 id="disciplines-tab"
                 data-bs-toggle="tab"
                 href="#disciplines"
@@ -687,7 +707,7 @@ class MdaViewer extends React.Component {
             </li>
             <li className="nav-item">
               <a
-                className="nav-link"
+                className={`nav-link ${tab_disabled}`}
                 id="connections-tab"
                 data-bs-toggle="tab"
                 href="#connections"
@@ -700,7 +720,7 @@ class MdaViewer extends React.Component {
             </li>
             <li className="nav-item">
               <a
-                className="nav-link active"
+                className={`nav-link ${tab_vars_active} ${tab_disabled}`}
                 id="variables-tab"
                 data-bs-toggle="tab"
                 href="#variables"
@@ -713,7 +733,7 @@ class MdaViewer extends React.Component {
             </li>
             <li className="nav-item">
               <a
-                className="nav-link"
+                className={`nav-link ${tab_disabled}`}
                 id="openmdao-impl-tab"
                 data-bs-toggle="tab"
                 href="#openmdao-impl"
@@ -727,6 +747,35 @@ class MdaViewer extends React.Component {
           </ul>
           <div className="tab-content" id="myTabContent">
             {errs}
+            <div className={`tab-pane fade ${tab_lock_show} ${tab_lock_active}`} id="lock" role="tabpanel" aria-labelledby="lock-tab">
+              <div className="container-fluid">
+                <div className="editor-section">
+                  <div className="editor-section-label">
+                    <i className="fas fa-lock" title="Analysis locked in readonly mode" />
+                    {' '}
+                    Readonly
+                    {' '}
+                    <small>
+                      (when locked, edition or deletion are disabled)
+                    </small>
+                  </div>
+                  <form className="form" onSubmit={this.handleAnalysisUpdate}>
+                    <div className="mb-3 form-check">
+                      <label htmlFor="locked" className="form-check-label">
+                        <input
+                          type="checkbox"
+                          className="form-check-input"
+                          defaultChecked={db.mda.locked}
+                          id="locked"
+                          onChange={this.handleAnalysisLockedChange}
+                        />
+                        Locked
+                      </label>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </div>
             <div className="tab-pane fade" id="analysis" role="tabpanel" aria-labelledby="analysis-tab">
               {mdaMsg}
               <AnalysisEditor
@@ -736,7 +785,6 @@ class MdaViewer extends React.Component {
                 note={db.mda.note}
                 newAnalysisName={newAnalysisName}
                 analysisPublic={mda.public}
-                analysisLocked={mda.locked}
                 analysisPermissionsEditable={analysisPermissionsEditable}
                 analysisMembers={analysisMembers}
                 analysisCoOwners={analysisCoOwners}
@@ -744,7 +792,6 @@ class MdaViewer extends React.Component {
                 onAnalysisNameChange={this.handleAnalysisNameChange}
                 onAnalysisNoteChange={this.handleAnalysisNoteChange}
                 onAnalysisPublicChange={this.handleAnalysisPublicChange}
-                onAnalysisLockedChange={this.handleAnalysisLockedChange}
                 onAnalysisUserSearch={this.handleAnalysisUserSearch}
                 onAnalysisUserSelected={this.handleAnalysisUserCreate}
                 onAnalysisUserDelete={this.handleAnalysisUserDelete}
@@ -778,7 +825,7 @@ class MdaViewer extends React.Component {
                 onConnectionDelete={this.handleConnectionDelete}
               />
             </div>
-            <div className="tab-pane fade show active" id="variables" role="tabpanel" aria-labelledby="variables-tab">
+            <div className={`tab-pane fade ${tab_vars_show} ${tab_vars_active}`} id="variables" role="tabpanel" aria-labelledby="variables-tab">
               {varEditor}
               <DistributionModals db={db} onConnectionChange={this.handleConnectionChange} />
             </div>

--- a/app/models/analysis.rb
+++ b/app/models/analysis.rb
@@ -46,8 +46,15 @@ class Analysis < ApplicationRecord
   validates :name, format: { with: /\A[a-zA-Z][_\.a-zA-Z0-9\s]*\z/, message: "%{value} is not a valid analysis name." }
 
   def journalized_attribute_names
-    ["name", "note_text", "design_project_name"]
+    ["name", "public", "locked", "note_text", "design_project_name"]
   end
+
+  def get_jounalized_attrs
+    self.attributes.merge!({
+      "note_text" => self.note.to_plain_text,
+      "design_project_name" => self.design_project&.name
+    })
+  end  
 
   def driver
     @driver ||= disciplines.driver.take

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -31,8 +31,8 @@ class Journal < ApplicationRecord
   def journalize_changes(journalized, old_attrs)
     journalized.journalized_attribute_names.each do |attr_name|
       # ensure an empty string as all attributes have not a null:false default
-      before = old_attrs[attr_name] || ""
-      after = journalized.send(attr_name)
+      before = old_attrs[attr_name].to_s || ""
+      after = journalized.send(attr_name).to_s
       unless before == after || (before.blank? && after.blank?)
         # Ensure value size less than 255 characters which correspond to field string max size in db 
         before = before.truncate(30)

--- a/app/policies/analysis_policy.rb
+++ b/app/policies/analysis_policy.rb
@@ -27,15 +27,19 @@ class AnalysisPolicy < ApplicationPolicy
     APP_CONFIG["enable_remote_operations"] && destroy?
   end
 
+  def unlock?
+    @user.has_role?(:owner, @record)
+  end
+
   def edit?
-    update?
+    @record.locked || update?
   end
 
   def update?
-    (@user.admin? || @user.has_role?(:owner, @record) || @user.has_role?(:co_owner, @record))
+    !@record.locked && (@user.admin? || @user.has_role?(:owner, @record) || @user.has_role?(:co_owner, @record))
   end
 
   def destroy?
-    @user.admin? || @user.has_role?(:owner, @record)
+    !@record.locked && (@user.admin? || @user.has_role?(:owner, @record))
   end
 end

--- a/app/policies/operation_policy.rb
+++ b/app/policies/operation_policy.rb
@@ -5,12 +5,16 @@ class OperationPolicy < ApplicationPolicy
     APP_CONFIG["enable_remote_operations"]
   end
 
+  def analysis_unlocked?
+    !@record.analysis.locked
+  end
+
   def show?
     AnalysisPolicy.new(@user, @record.analysis).show?
   end
 
   def create?
-    enable_remote_operations? && @user.has_role?(:owner, @record.analysis)
+    enable_remote_operations? && analysis_unlocked? && @user.has_role?(:owner, @record.analysis)
   end
 
   def update?
@@ -18,6 +22,6 @@ class OperationPolicy < ApplicationPolicy
   end
 
   def destroy?
-    (@user.admin? || @user.has_role?(:owner, @record.analysis))
+    analysis_unlocked? && (@user.admin? || @user.has_role?(:owner, @record.analysis))
   end
 end

--- a/app/policies/package_policy.rb
+++ b/app/policies/package_policy.rb
@@ -5,6 +5,10 @@ class PackagePolicy < ApplicationPolicy
     APP_CONFIG["enable_wopstore"]
   end
 
+  def analysis_unlocked?
+    !@record.analysis.locked
+  end
+
   class Scope < Scope
     def resolve
       scope.joins(:analysis).where(analyses: { id: Pundit.policy_scope!(@user, Analysis) })
@@ -22,15 +26,15 @@ class PackagePolicy < ApplicationPolicy
   end
 
   def edit?
-    enable_wopstore? && destroy?
+    destroy?
   end
 
   def update?
-    enable_wopstore? && destroy?
+    destroy?
   end
 
   # Admin can destroy edit/update/destroy packages
   def destroy?
-    enable_wopstore? && (@user.admin? || create?)
+    enable_wopstore? && analysis_unlocked? && (@user.admin? || create?)
   end
 end

--- a/app/views/analyses/_analyses.html.erb
+++ b/app/views/analyses/_analyses.html.erb
@@ -4,9 +4,9 @@
   <thead>
     <tr>
       <th style="width: 5%">#</th>
-      <th style="width: 20%">Name</th>
-      <th style="width: 5%">Owner</th>
-      <th style="width: 5%">Ownership</th>
+      <th style="width: 15%">Name</th>
+      <th style="width: 7%">Owner</th>
+      <th style="width: 8%">Access</th>
       <th style="width: 10%">Tag</th>
       <th style="width: 12%">Updated</th>
       <th style="width: 30%">Operations</th>
@@ -20,9 +20,7 @@
         <td>#<%= mda.id %></td>
         <td><%= link_to_analysis_if_authorized(mda, current_user) %></td>
         <td><%= mda&.owner&.login %></td>
-        <td>
-          <%= ownership(mda) %>
-        </td>
+        <td><%= analysis_access(mda) %></td>
         <td><%= badges(mda) %></td>
         <td><%= time_ago_in_words(mda.updated_at)%> ago</td>
         <td>

--- a/app/views/analyses/show.html.erb
+++ b/app/views/analyses/show.html.erb
@@ -11,7 +11,7 @@
   Copy
   <% end %>
   <% end %>
-  <% if policy(@mda).edit? %>
+  <% if policy(@mda).edit? || policy(@mda).unlock?%>
   <%= button_to edit_mda_path(@mda), method: :get, class:"btn" do |b|%>
   <span class="fa fa-edit"></span>
   Edit
@@ -41,6 +41,9 @@
 <h1><%= link_to_design_project_if_any(@mda) %><%= @mda.name%> 
   <small>
     <%= "(##{@mda.id})"%>
+    <% if @mda.locked %>
+      <i class="fas fa-lock" title="Analysis is readonly"></i>
+    <% end %>
     <% unless @mda.public %>
       <i class="fas fa-user-secret" title="Analysis with restricted access"></i>
     <% end %>

--- a/app/views/packages/index.html.erb
+++ b/app/views/packages/index.html.erb
@@ -18,7 +18,7 @@
     <% @packages.each do |pkg| %>
     <tr>
       <td><%= link_to_package_if_authorized(pkg, current_user) %></td>
-      <td><%= link_to_analysis_if_authorized(pkg.analysis, current_user) %><%=" (##{pkg.analysis.id})"%><%= ownership(pkg.analysis) %></td>
+      <td><%= link_to_analysis_if_authorized(pkg.analysis, current_user) %><%=" (##{pkg.analysis.id})"%><%= analysis_access(pkg.analysis) %></td>
       <td><%= pkg.analysis.owner.login %></td>
       <td><%= pkg.description %></td>
       <td><%= pkg.updated_at %></td>

--- a/db/migrate/20230426142546_add_locked_to_analysis.rb
+++ b/db/migrate/20230426142546_add_locked_to_analysis.rb
@@ -1,0 +1,5 @@
+class AddLockedToAnalysis < ActiveRecord::Migration[7.0]
+  def change
+    add_column :analyses, :locked, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_03_155358) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_26_142546) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -55,6 +55,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_03_155358) do
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "public", default: true
     t.string "ancestry"
+    t.integer "custom_config_id"
+    t.boolean "locked", default: false
     t.index ["ancestry"], name: "index_analyses_on_ancestry"
   end
 
@@ -146,6 +148,32 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_03_155358) do
     t.string "service_type"
     t.integer "service_id"
     t.index ["service_type", "service_id"], name: "index_endpoints_on_service_type_and_service_id"
+  end
+
+  create_table "fastoad_configs", force: :cascade do |t|
+    t.string "name"
+    t.string "version"
+    t.string "module_folders"
+    t.string "input_file"
+    t.string "output_file"
+    t.integer "analysis_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["analysis_id"], name: "index_fastoad_configs_on_analysis_id"
+  end
+
+  create_table "fastoad_modules", force: :cascade do |t|
+    t.string "name"
+    t.string "fastoad_id"
+    t.string "version"
+    t.integer "fastoad_config_id"
+    t.integer "custom_config_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "discipline_id"
+    t.index ["custom_config_id"], name: "index_fastoad_modules_on_custom_config_id"
+    t.index ["discipline_id"], name: "index_fastoad_modules_on_discipline_id"
+    t.index ["fastoad_config_id"], name: "index_fastoad_modules_on_fastoad_config_id"
   end
 
   create_table "geometry_models", force: :cascade do |t|
@@ -352,5 +380,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_03_155358) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "analysis_disciplines", "analyses"
   add_foreign_key "analysis_disciplines", "disciplines"
+  add_foreign_key "fastoad_configs", "analyses"
+  add_foreign_key "fastoad_modules", "disciplines"
+  add_foreign_key "fastoad_modules", "fastoad_configs"
+  add_foreign_key "fastoad_modules", "fastoad_configs", column: "custom_config_id"
   add_foreign_key "packages", "analyses"
 end

--- a/db/scratch_schema.rb
+++ b/db/scratch_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_03_155358) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_26_142546) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
     t.text "body"
@@ -55,6 +55,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_03_155358) do
     t.datetime "updated_at", precision: nil, null: false
     t.boolean "public", default: true
     t.string "ancestry"
+    t.integer "custom_config_id"
+    t.boolean "locked", default: false
     t.index ["ancestry"], name: "index_analyses_on_ancestry"
   end
 
@@ -130,6 +132,32 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_03_155358) do
     t.string "service_type"
     t.integer "service_id"
     t.index ["service_type", "service_id"], name: "index_endpoints_on_service_type_and_service_id"
+  end
+
+  create_table "fastoad_configs", force: :cascade do |t|
+    t.string "name"
+    t.string "version"
+    t.string "module_folders"
+    t.string "input_file"
+    t.string "output_file"
+    t.integer "analysis_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["analysis_id"], name: "index_fastoad_configs_on_analysis_id"
+  end
+
+  create_table "fastoad_modules", force: :cascade do |t|
+    t.string "name"
+    t.string "fastoad_id"
+    t.string "version"
+    t.integer "fastoad_config_id"
+    t.integer "custom_config_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "discipline_id"
+    t.index ["custom_config_id"], name: "index_fastoad_modules_on_custom_config_id"
+    t.index ["discipline_id"], name: "index_fastoad_modules_on_discipline_id"
+    t.index ["fastoad_config_id"], name: "index_fastoad_modules_on_fastoad_config_id"
   end
 
   create_table "geometry_models", force: :cascade do |t|
@@ -337,5 +365,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_03_155358) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "analysis_disciplines", "analyses"
   add_foreign_key "analysis_disciplines", "disciplines"
+  add_foreign_key "fastoad_configs", "analyses"
+  add_foreign_key "fastoad_modules", "disciplines"
+  add_foreign_key "fastoad_modules", "fastoad_configs"
+  add_foreign_key "fastoad_modules", "fastoad_configs", column: "custom_config_id"
   add_foreign_key "packages", "analyses"
 end

--- a/test/controllers/analyses_controller_test.rb
+++ b/test/controllers/analyses_controller_test.rb
@@ -168,6 +168,7 @@ class AnalysesControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal user2, copy.owner
     assert_equal @cicav.public, copy.public
+    assert_equal @cicav.locked, copy.locked
     assert_equal @cicav.design_project, copy.design_project
     assert_equal [], copy.members  # cicav public
   end

--- a/test/controllers/api/v1/analyses_controller_test.rb
+++ b/test/controllers/api/v1/analyses_controller_test.rb
@@ -210,7 +210,7 @@ class Api::V1::AnalysesControllerTest < ActionDispatch::IntegrationTest
     assert_equal @user1, inner.owner
   end
 
-  test "should update descendants attributes" do
+  test "should make descendants public" do
     @outer = analyses(:outermda)
     public = true
     patch api_v1_mda_url(@outer), params: { analysis: { public: public }, requested_at: Time.now }, as: :json, headers: @auth_headers
@@ -219,6 +219,17 @@ class Api::V1::AnalysesControllerTest < ActionDispatch::IntegrationTest
     public = false
     patch api_v1_mda_url(@outer), params: { analysis: { public: public }, requested_at: Time.now }, as: :json, headers: @auth_headers
     assert_equal public, @inner.reload.public
+  end
+
+  test "should lock descendants" do
+    @outer = analyses(:outermda)
+    locked = true
+    patch api_v1_mda_url(@outer), params: { analysis: { locked: locked }, requested_at: Time.now }, as: :json, headers: @auth_headers
+    @inner = analyses(:innermda)
+    assert_equal locked, @inner.locked
+    locked = false
+    patch api_v1_mda_url(@outer), params: { analysis: { locked: locked }, requested_at: Time.now }, as: :json, headers: @auth_headers
+    assert_equal locked, @inner.reload.locked
   end
 
   test "should have an openmdao implementation in whatsopt_ui json" do

--- a/test/controllers/api/v1/meta_models_controller_test.rb
+++ b/test/controllers/api/v1/meta_models_controller_test.rb
@@ -72,6 +72,7 @@ class Api::V1::MetaModelsControllerTest < ActionDispatch::IntegrationTest
     mda = Analysis.last
     assert_equal @user3, mda.owner
     assert_equal @mda.public, mda.public
+    assert_equal @mda.locked, mda.locked
     assert_equal @mda.design_project, mda.design_project
     assert_equal [], mda.members  # cicav is public
 


### PR DESCRIPTION
This PR adds the ability for the owner of an analysis to lock it in readonly mode.
It means that no direct access to delete or analysis update panels are available anymore. 
The owner can still unlock the analysis but he has to be aware of it 

This feature aims at protecting the analysis in the long term from any bad moves from the owner forgetting 
he wanted to keep the analysis because either results or package were attached to it. 
Note, at the moment, operation results and packages are also protected: direct delete or update actions are disabled when corresponding analysis is locked (will see if this has to be relaxed).